### PR TITLE
Appsody buildah CI enablement

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,11 @@
+language: bash
+os:
+- linux
+services:
+- docker
+deploy:
+  on:
+    branch: master
+    tags: true
+  provider: script
+  script: bash ./build.sh $CLI_VERSION $TRAVIS_TAG

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,6 +7,6 @@ RUN yum -y update && \
 # Matching appsody binary does not exist in upstream.
 # Provide the proper version once it is available.
 ARG CLI_VERSION
-RUN wget https://github.com/appsody/appsody/releases/download/CLI_VERSION/appsody-CLI_VERSION-1.x86_64.rpm
-RUN yum localinstall -y ./appsody-CLI_VERSION-1.x86_64.rpm
+RUN wget https://github.com/appsody/appsody/releases/download/$CLI_VERSION/appsody-$CLI_VERSION-1.x86_64.rpm
+RUN yum localinstall -y ./appsody-$CLI_VERSION-1.x86_64.rpm
 RUN chmod +x extract.sh

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,6 +6,7 @@ RUN yum -y update && \
       yum -y install wget
 # Matching appsody binary does not exist in upstream.
 # Provide the proper version once it is available.
+ARG CLI_VERSION
 RUN wget https://github.com/appsody/appsody/releases/download/CLI_VERSION/appsody-CLI_VERSION-1.x86_64.rpm
 RUN yum localinstall -y ./appsody-CLI_VERSION-1.x86_64.rpm
 RUN chmod +x extract.sh

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,6 +6,6 @@ RUN yum -y update && \
       yum -y install wget
 # Matching appsody binary does not exist in upstream.
 # Provide the proper version once it is available.
-RUN wget https://github.com/appsody/appsody/releases/download/0.X.0/appsody-0.X.0-1.x86_64.rpm
-RUN yum localinstall -y ./appsody-0.X.0-1.x86_64.rpm
+RUN wget https://github.com/appsody/appsody/releases/download/CLI_VERSION/appsody-CLI_VERSION-1.x86_64.rpm
+RUN yum localinstall -y ./appsody-CLI_VERSION-1.x86_64.rpm
 RUN chmod +x extract.sh

--- a/build.sh
+++ b/build.sh
@@ -3,7 +3,7 @@
 #CLI_VERSION
 #TRAVIS_TAG
 set -e
-sed -i  "s/CLI_VERSION/$1/g" ./Dockerfile
+#sed -i  "s/CLI_VERSION/$1/g" ./Dockerfile
 echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USERNAME" --password-stdin
-docker build -t $DOCKER_ORG/appsody-buildah:$2 .
+docker build -t $DOCKER_ORG/appsody-buildah:$2 --build-arg CLI_VERSION=$1 . 
 docker push $DOCKER_ORG/appsody-buildah:$2

--- a/build.sh
+++ b/build.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+#Takes two parms:
+#CLI_VERSION
+#TRAVIS_TAG
+set -e
+sed -i  "s/CLI_VERSION/$1/g" ./Dockerfile
+echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USERNAME" --password-stdin
+docker build -t $DOCKER_ORG/appsody-buildah:$2 .
+docker push $DOCKER_ORG/appsody-buildah:$2


### PR DESCRIPTION
Added `.travis.yaml` and `build.sh`. Noticed that I've also added a config environment variable to the repo called `CLI_VERSION` which refers to the the Appsody CLI version to be used.
The `build.sh` script takes two parms:
1) the CLI_VERSION
2) the TRAVIS_TAG, which is used to tag the image

Docker push only occurs when a tagged relesae is created.