### PR TITLE
dockerfile: omit inadvertant component upgrades

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,8 +2,7 @@
 # https://github.com/containers/buildah/issues/1821
 FROM quay.io/buildah/stable:v1.9.0
 COPY extract.sh .
-RUN yum -y update && \
-      yum -y install wget
+RUN yum -y install wget
 # Matching appsody binary does not exist in upstream.
 # Provide the proper version once it is available.
 ARG CLI_VERSION

--- a/extract.sh
+++ b/extract.sh
@@ -3,13 +3,6 @@
 # gitsource variable is supplied by the caller.
 cd /workspace/$gitsource
 
-# The below variable is used in extract for overlaying
-# the current location into the image file system.
-# Its necessity will depend on resolution of
-# https://github.com/appsody/stacks/issues/280
-# export APPSODY_MOUNT_PROJECT=`pwd`
-# echo APPSODY_MOUNT_PROJECT=${APPSODY_MOUNT_PROJECT}
-
 # Extract everything into /workspace/extracted, the image
 # content goes to the vortex, content in the current
 # folder into user-app, and the rest, as per the mounts.


### PR DESCRIPTION
An issue was reported as part of CRI-O pipeline testsing,
where a class of systems (specifically RHEL 7) were  failing.

While we stuck to `quay.io/buildah/stable:v1.9.0` , 
the `yum update` construct in the Dockerfile was 
upgrading the installed components in the image,
including `buildah`, taking us back to square one.

excerpts from `yum upgrade`:
```
Upgraded:
  audit-libs-3.0-0.9.20190507gitf58ec40.fc30.x86_64                             
  buildah-1.10.1-2.git8c1c2c5.fc30.x86_64                                       
...
```

All what we want is just `wget`, so skip `yum update`.