### PR TITLE
[WIP] dockerfile: upgrade buildah from v1.9.0 to latest

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,4 @@
-# Latest buildah is buggy use v1.9.0 until this is resolved:
-# https://github.com/containers/buildah/issues/1821
-FROM quay.io/buildah/stable:v1.9.0
+FROM quay.io/buildah/stable:latest
 COPY extract.sh .
 RUN yum -y install wget
 # Matching appsody binary does not exist in upstream.


### PR DESCRIPTION
buildah was fixed at v1.9.0 due to bind mount issues
when interacted with a buggy fuse-overlay module.
But this proved to be poorly performing for certain
stacks when exercised in the pipeline.

Upgrade buildah to latest that has the fix for the performance
issue, while documenting the requirement for fuse-overlay

Fixes: https://github.com/kabanero-io/kabanero-pipelines/issues/121
Refs: https://github.com/containers/buildah/issues/2047