### PR TITLE
Install git into image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,8 +2,7 @@
 # https://github.com/containers/buildah/issues/1821
 FROM quay.io/buildah/stable:v1.9.0
 COPY extract.sh .
-RUN yum -y install wget
-RUN yum -y install git
+RUN yum -y install wget git
 # Matching appsody binary does not exist in upstream.
 # Provide the proper version once it is available.
 ARG CLI_VERSION

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,6 +3,7 @@
 FROM quay.io/buildah/stable:v1.9.0
 COPY extract.sh .
 RUN yum -y install wget
+RUN yum -y install git
 # Matching appsody binary does not exist in upstream.
 # Provide the proper version once it is available.
 ARG CLI_VERSION


### PR DESCRIPTION
Fixes: https://github.com/appsody/appsody-buildah/issues/16

- Git labels couldn't be extracted before as git wasn't installed into the image. Also related to: https://github.com/appsody/appsody/pull/959